### PR TITLE
Support 160x128 indexed display mode

### DIFF
--- a/sources/ScreenRecorder.cpp
+++ b/sources/ScreenRecorder.cpp
@@ -3,6 +3,8 @@
  * |    Gamebuino META Screen Recorder     | 
  * | © 2019 Stéphane Calderoni (aka Steph) |
  * |     https://gamebuino.com/@steph      |
+ * | Contributor:                          |
+ * |        Erwin Bonsma (@eriban)         |
  * +---------------------------------------+
  */
 

--- a/sources/ScreenRecorder.h
+++ b/sources/ScreenRecorder.h
@@ -79,6 +79,7 @@ class ScreenRecorder
         static uint8_t screenWidth;
         static uint8_t screenHeight;
         static uint8_t sliceHeight;
+        static bool    indexed;
 
         static uint32_t timer;
         static uint32_t sendedBytes;
@@ -99,7 +100,7 @@ class ScreenRecorder
 
     public:
 
-        static void init(uint8_t sliceHeight = 64);
+        static void init(uint8_t sliceHeight = 64, bool indexed = false);
         static void setForWindows();
         static void monitor(uint16_t* buffer, uint16_t sliceIndex = 0);
         static void startRecording();

--- a/sources/ScreenRecorder.h
+++ b/sources/ScreenRecorder.h
@@ -3,6 +3,8 @@
  * |    Gamebuino META Screen Recorder     | 
  * | © 2019 Stéphane Calderoni (aka Steph) |
  * |     https://gamebuino.com/@steph      |
+ * | Contributor:                          |
+ * |        Erwin Bonsma (@eriban)         |
  * +---------------------------------------+
  */
 


### PR DESCRIPTION
Extended the screen recorder to support the 160x128 indexed display mode, where each pixel is stored using a 4-bit index. Before transferring, the data in the buffer must therefore be converted. 

The conversion code is based on that in Display_ST7735::drawImage(int16_t x, int16_t y, Image& img) in the original Gamebuino library, but optimized and simplified a bit.